### PR TITLE
add binrw (Rust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ file formats, network protocols or bitstreams.
 -   [Wuffs](https://github.com/google/wuffs): a memory-safe programming language (and a standard library written in that language) for Wrangling Untrusted File Formats Safely. 
     Wrangling includes parsing, decoding and encoding.
 -   [EverParse](https://project-everest.github.io/everparse/): a framework for generating verified secure parsers and formatters from domain-specific format specification languages
+-   [binrw](https://binrw.rs) (Rust): binrw helps you write maintainable & easy-to-read declarative binary data readers and writers using ✨macro magic✨.
 
 ### Stand-alone software
 


### PR DESCRIPTION
Request to add `binrw`, a Rust module which is working well for parsing complex files. 