### PR TITLE
Add antlr-rust-runtime to the Rust section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ A curated collection of tools and resources for parsing and analyzing binary dat
 -   [binrw](https://binrw.rs): binrw helps you write maintainable & easy-to-read declarative binary data readers and writers using ✨macro magic✨.
 -   [scroll](https://github.com/m4b/scroll): read and write structured data from byte buffers with Pread/Pwrite traits, endian-aware and derive-friendly
 -   [winnow](https://github.com/winnow-rs/winnow): parser combinator library forked from nom with improved error messages, better developer experience and active maintenance
+-   [antlr-rust-runtime](https://github.com/ophi-dev/antlr-rust-runtime): ANTLR v4 runtime and parser generator with a byte-oriented input stream, so grammars from [antlr/grammars-v4](https://github.com/antlr/grammars-v4) (e.g. bencoding) generate Rust parsers for binary formats. Length-prefixed framing is handled by typed hooks; generation is pure Rust, no JVM
 
 ### Ruby
 -   [BinData](https://github.com/dmendel/bindata):


### PR DESCRIPTION
Adds [`antlr-rust-runtime`](https://github.com/ophi-dev/antlr-rust-runtime) to the Rust section (disclosure: I maintain it).

### Why it belongs on a binary-parsing list

The list has no ANTLR entry today, and ANTLR is usually thought of as a text-parsing tool — but [ANTLR's own docs cover parsing binary files](https://github.com/antlr/antlr4/blob/dev/doc/parsing-binary-files.md), and the technique is genuinely useful here for one reason: [antlr/grammars-v4](https://github.com/antlr/grammars-v4) is a large public corpus of maintained grammars (1,142 `.g4` files), and a byte-oriented input stream turns the relevant ones into working Rust parsers without rewriting the format description.

This runtime recently gained a `ByteStream` where each byte is one symbol in `0..=255` and the stream index *is* the byte offset, which is what makes those grammars usable as-is.

### A concrete example, end to end

The canonical binary grammar in that corpus is [bencoding](https://github.com/antlr/grammars-v4/tree/master/bencoding) (the BitTorrent metadata encoding). Bencoded strings are length-prefixed — `26:abcdefghijklmnopqrstuvwXYZ` — which is data-dependent framing that no pure CFG can express, so upstream solves it with a lexer `superClass` in Java and C#:

```java
protected void setStringLength() { /* parse the N in "N:" */ }
protected boolean consumeStringChars() { return --this.stringLength > -1; }
```

Generating that grammar for Rust needs no changes to the `.g4` files. The generator maps the grammar's `{setStringLength();}` action and `{consumeStringChars()}?` predicate to two typed trait methods, and the `superClass` role becomes a small hooks impl:

```rust
impl BencodingLexerHooks for BencodingHooks {
    fn set_string_length<I>(&mut self, ctx: &mut LexerSemCtx<'_, I>) where I: CharStream {
        /* read the digits of the "N:" prefix back off the input */
    }
    fn consume_string_chars<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>) -> bool where I: CharStream {
        self.string_length -= 1;
        self.string_length > -1
    }
}
```

Then it parses over raw bytes:

```rust
let lexer = BencodingLexer::with_typed_hooks(ByteStream::new(bytes), BencodingHooks::default());
let mut parser = BencodingParser::new(CommonTokenStream::new(lexer));
parser.data()?;
```

I checked this rather than assuming it: all **8 of the grammar's own example files parse with zero syntax errors**, and the token stream is **identical to the Java reference implementation's** on every one of them (generated the Java parser with the ANTLR 4.13.2 jar, dumped both token-type sequences, diffed — no differences).

The repo also ships a worked [Standard MIDI File example](https://github.com/ophi-dev/antlr-rust-runtime/tree/main/tests/fixtures/antlr4-rust-gen/midi-binary) — chunk framing by declared length, VLQ delta-times, note-on/off and meta events — parsing a real `.mid` over `ByteStream` in an integration test.

### Honest scope

- This is a **parser generator**, not a declarative struct-mapping library. Compared to `binrw`/`deku`/`scroll` the trade is: you write a grammar rather than annotated structs, and you get a parse tree rather than filled-in types. It earns its place when a grammar for your format already exists, or when the format is genuinely grammatical (nested, recursive) rather than a flat record layout.
- Length-prefixed and other data-dependent formats need a few lines of host code, exactly as they do in ANTLR's other targets. `ByteStream` doesn't change that; it just removes the transcoding problem.
- Most of grammars-v4 is text-language grammars. bencoding is the binary one I've verified; I'm not claiming the corpus is full of binary formats.

Happy to trim the entry if it's too long for the list's style, or to drop it if a parser generator feels out of scope for the Rust section. I also wondered whether upstream ANTLR itself deserves a line under **Binary Format Description Languages** (alongside Kaitai Struct and Spicy) given its binary-parsing docs and the grammar corpus — glad to open that separately if you think it fits, since that one isn't my project.
